### PR TITLE
rule_sig_nameが空のパターンに対応する

### DIFF
--- a/lib/siteguard_lite/log/detect.rb
+++ b/lib/siteguard_lite/log/detect.rb
@@ -13,7 +13,7 @@ module SiteguardLite
       HIERARCHY_CODE = '(?<hierarchy_code>[^\s]+)'.freeze
       CONTENT_TYPE = '(?<content_type>[^\s]+)'.freeze
 
-      RULE_SIG = '(?<detect_name_rule>RULE_SIG)\/(?<rule_sig_part>[^\/]+)\/(?<rule_sig_name>[^\/]+)\/(?<rule_sig_file>(?:OFFICIAL|CUSTOM))\/(?<rule_sig_id>[^\/]+)\/(?<rule_sig_signature_name>[\w\d-]+)'.freeze
+      RULE_SIG = '(?<detect_name_rule>RULE_SIG)\/(?<rule_sig_part>[^\/]+)\/(?<rule_sig_name>[^\/]?+)\/(?<rule_sig_file>(?:OFFICIAL|CUSTOM))\/(?<rule_sig_id>[^\/]+)\/(?<rule_sig_signature_name>[\w\d-]+)'.freeze
       WAF_FILTER = '(?<detect_name_rule>WAF_FILTER)'.freeze
       RULE_URLDECODE = '(?<detect_name_rule>RULE_URLDECODE)'.freeze
       RULE_PARAMS_NUM = '(?<detect_name_rule>RULE_PARAMS_NUM)\/(?<rule_params_num_part>[^\/]+)\/(?<rule_params_num_threshold>\d+)'.freeze

--- a/spec/siteguard_lite/log/detect_spec.rb
+++ b/spec/siteguard_lite/log/detect_spec.rb
@@ -70,6 +70,17 @@ RSpec.describe SiteguardLite::Log::Detect do
       end
     end
 
+    context 'when rule_sig_name empty' do
+      let(:sample) {
+        <<~EOD
+          1531397957.965300      0 192.168.0.100 TCP_MISS/000 0 GET http://example.com/?p=<script>alert(%22hello%22)</script> - DIRECT/192.168.1.100 - DETECT-STAT:WAF:RULE_SIG/PART_PARAM_VALUE|PART_GET_PARAM//OFFICIAL/00102001/xss-tag-1::%3cscript%3e:%3cscript%3ealert(%22hello%22)%3c/script%3e: ACTION:BLOCK: JUDGE:BLOCK:0: SEARCH-KEY:1531397957.965300.76402:
+        EOD
+      }
+
+      it { expect(subject['detect_name']).to eq 'RULE_SIG/PART_PARAM_VALUE|PART_GET_PARAM//OFFICIAL/00102001/xss-tag-1' }
+      it { expect(subject['rule_sig_name']).to eq '' }
+    end
+
     context 'when leading time exist' do
       # The downloaded logs have leading time, and the logs saved in the servers do not.
       subject { SiteguardLite::Log::Detect.new(leading_time: true).parse(sample) }


### PR DESCRIPTION
以下のログの場合にパースに失敗するため対応しました。

```
1531397957.965300      0 192.168.0.100 TCP_MISS/000 0 GET http://example.com/?p=<script>alert(%22hello%22)</script> - DIRECT/192.168.1.100 - DETECT-STAT:WAF:RULE_SIG/PART_PARAM_VALUE|PART_GET_PARAM//OFFICIAL/00102001/xss-tag-1::%3cscript%3e:%3cscript%3ealert(%22hello%22)%3c/script%3e: ACTION:BLOCK: JUDGE:BLOCK:0: SEARCH-KEY:1531397957.965300.76402:
```

これまでは以下のパターンを想定していた。

```
DETECT-STAT:WAF:RULE_SIG/PART_PARAM_VALUE|PART_GET_PARAM/p/OFFICIAL/00102001/xss-tag-1
```

以下のように `p` がないパターンが想定されていなかった。
```
DETECT-STAT:WAF:RULE_SIG/PART_PARAM_VALUE|PART_GET_PARAM//OFFICIAL/00102001/xss-tag-1
```

```rb
# return empty hash

SiteguardLite::Log::Detect.new().parse(str)
#=> {}
```
