### PR TITLE
バージョンを0.1.1に上げる

### DIFF
--- a/lib/siteguard_lite/log/parser/version.rb
+++ b/lib/siteguard_lite/log/parser/version.rb
@@ -1,7 +1,7 @@
 module SiteguardLite
   module Log
     module Parser
-      VERSION = "0.1.0"
+      VERSION = "0.1.1"
     end
   end
 end


### PR DESCRIPTION
以下の修正を含むバージョンを `0.1.1` でリリースします。

- [rule_sig_nameが空のパターンに対応する](https://github.com/pepabo/siteguard_lite-log-parser/pull/1)