### PR TITLE
rule_sig_nameが2文字以上の場合にパースできなくなっていたため修正

### DIFF
--- a/lib/siteguard_lite/log/detect.rb
+++ b/lib/siteguard_lite/log/detect.rb
@@ -13,7 +13,7 @@ module SiteguardLite
       HIERARCHY_CODE = '(?<hierarchy_code>[^\s]+)'.freeze
       CONTENT_TYPE = '(?<content_type>[^\s]+)'.freeze
 
-      RULE_SIG = '(?<detect_name_rule>RULE_SIG)\/(?<rule_sig_part>[^\/]+)\/(?<rule_sig_name>[^\/]?+)\/(?<rule_sig_file>(?:OFFICIAL|CUSTOM))\/(?<rule_sig_id>[^\/]+)\/(?<rule_sig_signature_name>[\w\d-]+)'.freeze
+      RULE_SIG = '(?<detect_name_rule>RULE_SIG)\/(?<rule_sig_part>[^\/]+)\/(?<rule_sig_name>[^\/]*+)\/(?<rule_sig_file>(?:OFFICIAL|CUSTOM))\/(?<rule_sig_id>[^\/]+)\/(?<rule_sig_signature_name>[\w\d-]+)'.freeze
       WAF_FILTER = '(?<detect_name_rule>WAF_FILTER)'.freeze
       RULE_URLDECODE = '(?<detect_name_rule>RULE_URLDECODE)'.freeze
       RULE_PARAMS_NUM = '(?<detect_name_rule>RULE_PARAMS_NUM)\/(?<rule_params_num_part>[^\/]+)\/(?<rule_params_num_threshold>\d+)'.freeze

--- a/lib/siteguard_lite/log/parser/version.rb
+++ b/lib/siteguard_lite/log/parser/version.rb
@@ -1,7 +1,7 @@
 module SiteguardLite
   module Log
     module Parser
-      VERSION = "0.1.1"
+      VERSION = "0.1.2"
     end
   end
 end

--- a/spec/siteguard_lite/log/detect_spec.rb
+++ b/spec/siteguard_lite/log/detect_spec.rb
@@ -81,6 +81,17 @@ RSpec.describe SiteguardLite::Log::Detect do
       it { expect(subject['rule_sig_name']).to eq '' }
     end
 
+    context 'when rule_sig_name 2 or more characters' do
+      let(:sample) {
+        <<~EOD
+          1531397957.965300      0 192.168.0.100 TCP_MISS/000 0 GET http://example.com/?p=<script>alert(%22hello%22)</script> - DIRECT/192.168.1.100 - DETECT-STAT:WAF:RULE_SIG/PART_PARAM_VALUE|PART_GET_PARAM/Content-Type/OFFICIAL/00102001/xss-tag-1::%3cscript%3e:%3cscript%3ealert(%22hello%22)%3c/script%3e: ACTION:BLOCK: JUDGE:BLOCK:0: SEARCH-KEY:1531397957.965300.76402:
+        EOD
+      }
+
+      it { expect(subject['detect_name']).to eq 'RULE_SIG/PART_PARAM_VALUE|PART_GET_PARAM/Content-Type/OFFICIAL/00102001/xss-tag-1' }
+      it { expect(subject['rule_sig_name']).to eq 'Content-Type' }
+    end
+
     context 'when leading time exist' do
       # The downloaded logs have leading time, and the logs saved in the servers do not.
       subject { SiteguardLite::Log::Detect.new(leading_time: true).parse(sample) }


### PR DESCRIPTION
デグレードしていたので修正しました。

1. `RULE_SIG/PART_PARAM_VALUE|PART_GET_PARAM/p/` 
1. `RULE_SIG/PART_PARAM_VALUE|PART_GET_PARAM//`
1. `RULE_SIG/PART_PARAM_VALUE|PART_GET_PARAM/Content-Type/` 

上記のようなログパターンがあって、 https://github.com/pepabo/siteguard_lite-log-parser/pull/1 で `2` に対応したが `3` のように、2文字以上の場合にパースできなくなっていたため修正した。