### PR TITLE
detect_strとdetect_str_allの間に”：”が２個設定されていた場合にパースできなくなっていたため修正 

### DIFF
--- a/lib/siteguard_lite/log/detect.rb
+++ b/lib/siteguard_lite/log/detect.rb
@@ -18,7 +18,7 @@ module SiteguardLite
       RULE_URLDECODE = '(?<detect_name_rule>RULE_URLDECODE)'.freeze
       RULE_PARAMS_NUM = '(?<detect_name_rule>RULE_PARAMS_NUM)\/(?<rule_params_num_part>[^\/]+)\/(?<rule_params_num_threshold>\d+)'.freeze
       DETECT_NAME = "(?<detect_name>(?:#{RULE_SIG}|#{WAF_FILTER}|#{RULE_URLDECODE}|#{RULE_PARAMS_NUM}))".freeze
-      DETECT_STAT = "(?<detect_stat>DETECT-STAT:WAF:#{DETECT_NAME}::(?<detect_str>[^:]*):(?<detect_str_all>[^:]+):)".freeze
+      DETECT_STAT = "(?<detect_stat>DETECT-STAT:WAF:#{DETECT_NAME}::(?<detect_str>[^:]*)(:|::)(?<detect_str_all>[^:]+):)".freeze
 
       ACTION = '(?<action>ACTION:(?<action_str>[A-Z]+):)'.freeze
       JUDGE = '(?<judge>JUDGE:(?<judge_str>[A-Z]+):(?<monitor_url>0|1):)'.freeze


### PR DESCRIPTION
以下のログの場合にパースに失敗するため対応しました。
```
2020-03-08 09:06:59 : 1583626019.648624      0 153.156.46.115 TCP_MISS/000 0 GET http://lolipop.jp/manual/user/osaipo-attest/%7b%7baddLinkHash%28item.link,+keyword%29%7d%7d - DIRECT/133.130.35.170 - DETECT-STAT:WAF:RULE_SIG/PART_PATH//OFFICIAL/00201114/sqlinj-114::-attest/%7b%7baddLinkHash(item.link%2c+keyword):: ACTION:BLOCK: JUDGE:BLOCK:0: SEARCH-KEY:1583626019.648624.67885:
```

- `(?<detect_str>[^:]*):`の正規表現を `::`にも対応するように修正します